### PR TITLE
fix: simplify libvips dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,35 +26,13 @@ RUN \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg >/dev/null && \
   apt-get update && \
   apt-get install --no-install-recommends -y \
+    $(apt-cache depends libvips-dev | awk '/Depends:/{print $2}' | grep -v '[<>]') \
     bc \
     build-essential \
     ffmpeg \
     g++ \
-    libcfitsio-dev \
-    libexif-dev \
-    libexpat1-dev \
-    libfftw3-dev \
-    libgirepository1.0-dev \
-    libglib2.0-dev \
-    libgsf-1-dev \
-    libheif-dev \
-    libimagequant-dev \
-    libjpeg-dev \
-    libjpeg-turbo8-dev \
-    libjxl-dev \
     libltdl-dev \
-    libmatio-dev \
-    libopenexr-dev \
-    libopenjp2-7-dev \
-    libopenslide-dev \
-    liborc-dev \
-    libpango1.0-dev \
-    libpng-dev \
-    libpoppler-glib-dev \
     libraw-dev \
-    librsvg2-dev \
-    libtiff-dev \
-    libwebp-dev \
     make \
     meson \
     nginx \
@@ -180,6 +158,7 @@ RUN \
     bc \
     build-essential \
     g++ \
+    libltdl-dev \
     make \
     meson \
     ninja-build \


### PR DESCRIPTION
Simplify the install for libvips dependencies. With it, we are sure to install all required dependencies, even when the base image changes.