### PR TITLE
fix: allow DB_URL

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-check-variables/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-check-variables/run
@@ -8,9 +8,11 @@ check_var() {
     fi
 }
 
+if [ -z "${DB_URL}" ]; then
 #         Variable           Variable Summary                Additional Message
 check_var "DB_HOSTNAME"      "PostgreSQL database host"
 check_var "DB_USERNAME"      "PostgreSQL database user"
 check_var "DB_PASSWORD"      "PostgreSQL database password"
 check_var "DB_DATABASE_NAME" "PostgreSQL database name"
+fi
 check_var "REDIS_HOSTNAME"   "Redis host"


### PR DESCRIPTION
Immich allows to set the database parameters with `DB_HOSTNAME`, `DB_USERNAME`, `DB_PASSWORD`, `DB_DATABASE_NAME` or with only `DB_URL`. With this PR if `DB_URL` is set it does not check if  `DB_HOSTNAME` and other  envs are set.