### PR TITLE
fix: check if redis_socket or redis_url are set (main)

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-check-variables/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-check-variables/run
@@ -15,6 +15,6 @@ check_var "DB_USERNAME"      "PostgreSQL database user"
 check_var "DB_PASSWORD"      "PostgreSQL database password"
 check_var "DB_DATABASE_NAME" "PostgreSQL database name"
 fi
-if [ -z "${REDIS_SOCKET}" ] || [ -z "${REDIS_URL}" ]; then
+if [ -z "${REDIS_SOCKET}" ] && [ -z "${REDIS_URL}" ]; then
 check_var "REDIS_HOSTNAME"   "Redis host"
 fi


### PR DESCRIPTION
Fix #156. `-z` returns `true` if the variable is empty...