### PR TITLE
fix: use same version as immich

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,8 @@ RUN \
   mkdir -p \
     /tmp/libraw && \
   if [ -z ${LIBRAW_VERSION} ]; then \
-    LIBRAW_VERSION=$(curl -sL https://api.github.com/repos/libraw/libraw/releases/latest | \
-      jq -r '.tag_name'); \
+    LIBRAW_VERSION=$(jq -r '.packages[] | select(.name == "libraw") | .version' \
+      /tmp/immich/server/build-lock.json); \
   fi && \
   curl -o \
     /tmp/libraw.tar.gz -L \
@@ -90,8 +90,8 @@ RUN \
   mkdir -p \
     /tmp/imagemagick && \
   if [ -z ${IMAGE_MAGICK_VERSION} ]; then \
-    IMAGE_MAGICK_VERSION=$(curl -sL https://api.github.com/repos/ImageMagick/ImageMagick/releases/latest | \
-      jq -r '.tag_name'); \
+    IMAGE_MAGICK_VERSION=$(jq -r '.packages[] | select(.name == "imagemagick") | .version' \
+      /tmp/immich/server/build-lock.json); \
   fi && \
   curl -o \
     /tmp/imagemagick.tar.gz -L \
@@ -111,8 +111,8 @@ RUN \
   mkdir -p \
     /tmp/libvips && \
   if [ -z ${IMAGE_LIBVIPS_VERSION} ]; then \
-    IMAGE_LIBVIPS_VERSION=$(curl -sL https://api.github.com/repos/libvips/libvips/releases/latest | \
-      jq -r '.tag_name'); \
+    IMAGE_LIBVIPS_VERSION=v$(jq -r '.packages[] | select(.name == "libvips") | .version' \
+      /tmp/immich/server/build-lock.json); \
   fi && \
   curl -o \
     /tmp/libvips.tar.gz -L \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -68,8 +68,8 @@ RUN \
   mkdir -p \
     /tmp/libraw && \
   if [ -z ${LIBRAW_VERSION} ]; then \
-    LIBRAW_VERSION=$(curl -sL https://api.github.com/repos/libraw/libraw/releases/latest | \
-      jq -r '.tag_name'); \
+    LIBRAW_VERSION=$(jq -r '.packages[] | select(.name == "libraw") | .version' \
+      /tmp/immich/server/build-lock.json); \
   fi && \
   curl -o \
     /tmp/libraw.tar.gz -L \
@@ -89,8 +89,8 @@ RUN \
   mkdir -p \
     /tmp/imagemagick && \
   if [ -z ${IMAGE_MAGICK_VERSION} ]; then \
-    IMAGE_MAGICK_VERSION=$(curl -sL https://api.github.com/repos/ImageMagick/ImageMagick/releases/latest | \
-      jq -r '.tag_name'); \
+    IMAGE_MAGICK_VERSION=$(jq -r '.packages[] | select(.name == "imagemagick") | .version' \
+      /tmp/immich/server/build-lock.json); \
   fi && \
   curl -o \
     /tmp/imagemagick.tar.gz -L \
@@ -110,8 +110,8 @@ RUN \
   mkdir -p \
     /tmp/libvips && \
   if [ -z ${IMAGE_LIBVIPS_VERSION} ]; then \
-    IMAGE_LIBVIPS_VERSION=$(curl -sL https://api.github.com/repos/libvips/libvips/releases/latest | \
-      jq -r '.tag_name'); \
+    IMAGE_LIBVIPS_VERSION=v$(jq -r '.packages[] | select(.name == "libvips") | .version' \
+      /tmp/immich/server/build-lock.json); \
   fi && \
   curl -o \
     /tmp/libvips.tar.gz -L \


### PR DESCRIPTION
Instead of using latest versions of libvips, libraw and imagemagick, it uses now the same versions as Immich.