### PR TITLE
fix!: machine-learning dependencies in v1.84

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,8 @@ RUN \
     python3-dev \
     wget && \
   echo "**** install runtime packages ****" && \
-  echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x lunar main" >>/etc/apt/sources.list.d/node.list && \
-  curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg >/dev/null && \
+  echo "deb [signed-by=/usr/share/keyrings/nodesource-repo.gpg] https://deb.nodesource.com/node_18.x nodistro main" >>/etc/apt/sources.list.d/node.list && \
+  curl -s https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource-repo.gpg >/dev/null && \
   apt-get update && \
   apt-get install --no-install-recommends -y \
     intel-media-va-driver-non-free \

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,6 @@ RUN \
   poetry config installer.max-workers 10 && \
   poetry config virtualenvs.create false && \
   poetry install --sync --no-interaction --no-ansi --no-root --only main && \
-  poetry run pip install --no-deps -r requirements.txt && \
   mkdir -p \
     /app/immich/machine-learning && \
   cp -a \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -148,7 +148,6 @@ RUN \
   poetry config installer.max-workers 10 && \
   poetry config virtualenvs.create false && \
   poetry install --sync --no-interaction --no-ansi --no-root --only main && \
-  poetry run pip install --no-deps -r requirements.txt && \
   mkdir -p \
     /app/immich/machine-learning && \
   cp -a \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -49,8 +49,8 @@ RUN \
     python3-dev \
     wget && \
   echo "**** install runtime packages ****" && \
-  echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x lunar main" >>/etc/apt/sources.list.d/node.list && \
-  curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg >/dev/null && \
+  echo "deb [signed-by=/usr/share/keyrings/nodesource-repo.gpg] https://deb.nodesource.com/node_18.x nodistro main" >>/etc/apt/sources.list.d/node.list && \
+  curl -s https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource-repo.gpg >/dev/null && \
   apt-get update && \
   apt-get install --no-install-recommends -y \
     libexif12 \


### PR DESCRIPTION
> [!WARNING]  
> Breaking changes for v1.84.0

v1.84.0 will bring breaking changes for the machine learning install. requirements.txt won't be used anymore.

This needs to be merged after v.84.0 is out

https://github.com/immich-app/immich/pull/4700