### PR TITLE
feat: store geocoding dump in config folder (main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ ENV \
   TYPESENSE_DATA_DIR="/config/typesense" \
   TYPESENSE_API_KEY="xyz" \
   TYPESENSE_HOST="127.0.0.1" \
-  TYPESENSE_VERSION="0.24.1"
+  TYPESENSE_VERSION="0.24.1" \
+  REVERSE_GEOCODING_DUMP_DIRECTORY="/config/.reverse-geocoding-dump/"
 
 RUN \
   echo "**** install build packages ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -19,7 +19,8 @@ ENV \
   TYPESENSE_DATA_DIR="/config/typesense" \
   TYPESENSE_API_KEY="xyz" \
   TYPESENSE_HOST="127.0.0.1" \
-  TYPESENSE_VERSION="0.24.1"
+  TYPESENSE_VERSION="0.24.1" \
+  REVERSE_GEOCODING_DUMP_DIRECTORY="/config/.reverse-geocoding-dump/"
 
 RUN \
   echo "**** install build packages ****" && \


### PR DESCRIPTION
Currently, every time a new Docker image is created, Immich downloads the reverse geocoding dump files and saves them in the /app/immich/server/.reverse-geocoding-dump directory. With this PR, Immich will download these files only once and store them in `/config/.reverse-geocoding-dump` using  the [`REVERSE_GEOCODING_DUMP_DIRECTORY`](https://immich.app/docs/install/environment-variables#geocoding) env.