### PR TITLE
feat!: use depedencies in base image repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,13 +97,21 @@ RUN \
   tar xf \
     /tmp/immich.tar.gz -C \
     /tmp/immich --strip-components=1 && \
+  echo "**** download immich dependencies ****" && \
+  mkdir -p \
+    /tmp/immich-dependencies && \
+  curl -o \
+    /tmp/immich-dependencies.tar.gz -L \
+    "https://github.com/immich-app/base-images/archive/main.tar.gz" && \
+  tar xf \
+    /tmp/immich-dependencies.tar.gz -C \
+    /tmp/immich-dependencies --strip-components=1 && \
   echo "**** build immich dependencies ****" && \
-  cd /tmp/immich/server && \
-  bin/install-ffmpeg.sh && \
-  bin/build-libraw.sh || bin/build-libraw.sh && \
-  mv bin/use-camera-wb.patch . && \
-  bin/build-imagemagick.sh && \
-  bin/build-libvips.sh && \
+  cd /tmp/immich-dependencies/server/bin && \
+  ./install-ffmpeg.sh && \
+  ./build-libraw.sh || ./build-libraw.sh && \
+  ./build-imagemagick.sh && \
+  ./build-libvips.sh && \
   echo "**** download typesense ****" && \
   mkdir -p \
     /app/typesense && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -96,13 +96,21 @@ RUN \
   tar xf \
     /tmp/immich.tar.gz -C \
     /tmp/immich --strip-components=1 && \
+  echo "**** download immich dependencies ****" && \
+  mkdir -p \
+    /tmp/immich-dependencies && \
+  curl -o \
+    /tmp/immich-dependencies.tar.gz -L \
+    "https://github.com/immich-app/base-images/archive/main.tar.gz" && \
+  tar xf \
+    /tmp/immich-dependencies.tar.gz -C \
+    /tmp/immich-dependencies --strip-components=1 && \
   echo "**** build immich dependencies ****" && \
-  cd /tmp/immich/server && \
-  bin/install-ffmpeg.sh && \
-  bin/build-libraw.sh || bin/build-libraw.sh && \
-  mv bin/use-camera-wb.patch . && \
-  bin/build-imagemagick.sh && \
-  bin/build-libvips.sh && \
+  cd /tmp/immich-dependencies/server/bin && \
+  ./install-ffmpeg.sh && \
+  ./build-libraw.sh || ./build-libraw.sh && \
+  ./build-imagemagick.sh && \
+  ./build-libvips.sh && \
   echo "**** download typesense ****" && \
   mkdir -p \
     /app/typesense && \


### PR DESCRIPTION
Immich will use a base image and all the build scripts will be in [this repo](https://github.com/immich-app/base-images). 

Related PR : https://github.com/immich-app/immich/pull/4456