### PR TITLE
feat: geocoding (main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,7 @@ RUN \
     python3 \
     python3-pip \
     python3-venv \
+    unzip \
     zlib1g && \
   echo "**** download immich ****" && \
   mkdir -p \
@@ -106,6 +107,22 @@ RUN \
   tar xf \
     /tmp/immich-dependencies.tar.gz -C \
     /tmp/immich-dependencies --strip-components=1 && \
+  echo "**** download geocoding data ****" && \
+  mkdir -p \
+    /usr/src/resources && \
+  curl -o \
+    /tmp/cities500.zip -L \
+    "https://download.geonames.org/export/dump/cities500.zip" && \
+  curl -o \
+    /usr/src/resources/admin1CodesASCII.txt -L \
+    "https://download.geonames.org/export/dump/admin1CodesASCII.txt" && \
+  curl -o \
+    /usr/src/resources/admin2Codes.txt -L \
+    "https://download.geonames.org/export/dump/admin2Codes.txt" && \
+  unzip \
+    /tmp/cities500.zip -d \
+    /usr/src/resources && \
+  date --iso-8601=seconds | tr -d "\n" > /usr/src/resources/geodata-date.txt && \
   echo "**** build immich dependencies ****" && \
   cd /tmp/immich-dependencies/server/bin && \
   ./install-ffmpeg.sh && \
@@ -191,6 +208,7 @@ RUN \
     ninja-build \
     pkg-config \
     python3-dev \
+    unzip \
     wget && \
   apt-get autoremove -y --purge && \
   apt-get clean && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -80,6 +80,7 @@ RUN \
     python3 \
     python3-pip \
     python3-venv \
+    unzip \
     zlib1g && \
   echo "**** download immich ****" && \
   mkdir -p \
@@ -103,6 +104,22 @@ RUN \
   tar xf \
     /tmp/immich-dependencies.tar.gz -C \
     /tmp/immich-dependencies --strip-components=1 && \
+  echo "**** download geocoding data ****" && \
+  mkdir -p \
+    /usr/src/resources && \
+  curl -o \
+    /tmp/cities500.zip -L \
+    "https://download.geonames.org/export/dump/cities500.zip" && \
+  curl -o \
+    /usr/src/resources/admin1CodesASCII.txt -L \
+    "https://download.geonames.org/export/dump/admin1CodesASCII.txt" && \
+  curl -o \
+    /usr/src/resources/admin2Codes.txt -L \
+    "https://download.geonames.org/export/dump/admin2Codes.txt" && \
+  unzip \
+    /tmp/cities500.zip -d \
+    /usr/src/resources && \
+  date --iso-8601=seconds | tr -d "\n" > /usr/src/resources/geodata-date.txt && \
   echo "**** build immich dependencies ****" && \
   cd /tmp/immich-dependencies/server/bin && \
   ./install-ffmpeg.sh && \
@@ -188,6 +205,7 @@ RUN \
     ninja-build \
     pkg-config \
     python3-dev \
+    unzip \
     wget && \
   apt-get autoremove -y --purge && \
   apt-get clean && \


### PR DESCRIPTION
Currently, Immich relies on a [npm package](https://www.npmjs.com/package/local-reverse-geocoder) for retrieving city and country names based on geographical coordinates. However this package has been associated with potential crashes and excessive RAM usage. In response to these issues, there is an open PR to transition away from this package by incorporating a more stable approach (by loading the geocoding data into a PostgreSQL table). But the geocoding data is not loaded when the server starts like it's done currently with the npm package but when the image is built. 

This PR adds the geocoding data during the build, you can see here how it's done with the [Immich base image](https://github.com/immich-app/base-images/pull/15) 