### PR TITLE
feat: move to ubuntu mantic (main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/imagegenius/baseimage-ubuntu:lunar
+FROM ghcr.io/imagegenius/baseimage-ubuntu:mantic
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/imagegenius/baseimage-ubuntu:arm64v8-lunar
+FROM ghcr.io/imagegenius/baseimage-ubuntu:arm64v8-mantic
 
 # set version label
 ARG BUILD_DATE

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -123,6 +123,7 @@ external_application_unraid_block: |
 
 # changelog
 changelogs:
+  - { date: "07.12.23:", desc: "move to ubuntu mantic" }
   - { date: "07.12.23:", desc: "remove typesense (no longer needed)" }
   - { date: "08.11.23:", desc: "move to using seperate immich baseimage" }
   - { date: "24.09.23:", desc: "house cleaning" }


### PR DESCRIPTION
Move the base image to Ubuntu mantic (23.10). Tested with raw, heic and jpeg images.

Next step, Ubuntu 24.04 LTS 😏