### PR TITLE
fix: downloading machine learning models (main)

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-machine-learning/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-machine-learning/run
@@ -10,6 +10,7 @@
 lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2"
 export LD_PRELOAD="$lib_path"
 export MPLCONFIGDIR="/tmp"
+export HF_HOME="/tmp"
 
 exec \
     cd /app/immich/machine-learning s6-setuidgid abc \


### PR DESCRIPTION
fix downloading models for a new instance #284

I tried again after a few months and it seems that now `HF_HOME` is finally being used by the machine learning process :tada: 