### PR TITLE
fix: prevent installing dev packages for machine-learning (main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,7 @@ RUN \
     /app/immich/server/www  && \
   echo "**** build machine-learning ****" && \
   mkdir -p \
-    /app/immich/machine-learning/ann \
-    /app/immich/machine-learning/cuda && \
+    /app/immich/machine-learning/ann && \
   cd /tmp/immich/machine-learning && \
   pip install --break-system-packages -U --no-cache-dir \
     poetry && \
@@ -100,17 +99,8 @@ RUN \
     log_conf.json \
     /app/immich/machine-learning && \
   cp -a \
-    pyproject.toml \
-    poetry.lock \
-    /app/immich/machine-learning/cuda && \
-  cp -a \
     ann/ann.py \
     /app/immich/machine-learning/ann && \
-  echo "**** change machine learning dependencies for cuda acceleration ****" && \
-  cd /app/immich/machine-learning/cuda && \
-  poetry source add --no-interaction --no-ansi --priority=supplemental cuda12 https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/ && \
-  poetry remove --lock --no-interaction --no-ansi --group cuda onnxruntime-gpu && \
-  poetry add --lock --no-interaction --no-ansi --source cuda12 --group cuda onnxruntime-gpu && \
   echo "**** cleanup ****" && \
   for cleanfiles in *.pyc *.pyo; do \
     find /usr/local/lib/python3.* /usr/lib/python3.* /lsiopy/lib/python3.* -name "${cleanfiles}" -delete; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,9 +108,9 @@ RUN \
     /app/immich/machine-learning/ann && \
   echo "**** change machine learning dependencies for cuda acceleration ****" && \
   cd /app/immich/machine-learning/cuda && \
-  poetry source add --no-interaction --no-ansi --priority=supplemental ort https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ort-cuda-12-nightly/pypi/simple/ && \
-  poetry add --lock --no-interaction --no-ansi --source ort --group cuda ort-nightly-gpu && \
+  poetry source add --no-interaction --no-ansi --priority=supplemental cuda12 https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/ && \
   poetry remove --lock --no-interaction --no-ansi --group cuda onnxruntime-gpu && \
+  poetry add --lock --no-interaction --no-ansi --source cuda12 --group cuda onnxruntime-gpu && \
   echo "**** cleanup ****" && \
   for cleanfiles in *.pyc *.pyo; do \
     find /usr/local/lib/python3.* /usr/lib/python3.* /lsiopy/lib/python3.* -name "${cleanfiles}" -delete; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,11 @@ LABEL maintainer="hydazz, martabal"
 ENV \
   IMMICH_MACHINE_LEARNING_URL="http://127.0.0.1:3003" \
   IMMICH_MEDIA_LOCATION="/photos" \
-  MACHINE_LEARNING_CACHE_FOLDER="/config/machine-learning/models" \
-  TRANSFORMERS_CACHE="/config/machine-learning/models" \
-  SERVER_PORT="8080" \
   IMMICH_WEB_ROOT="/app/immich/server/www" \
-  NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
+  MACHINE_LEARNING_CACHE_FOLDER="/config/machine-learning/models" \
+  NVIDIA_DRIVER_CAPABILITIES="compute,video,utility" \
+  SERVER_PORT="8080" \
+  TRANSFORMERS_CACHE="/config/machine-learning/models"
 
 RUN \
   echo "**** install build packages ****" && \
@@ -108,9 +108,9 @@ RUN \
     /app/immich/machine-learning/ann && \
   echo "**** change machine learning dependencies for cuda acceleration ****" && \
   cd /app/immich/machine-learning/cuda && \
-  poetry source add --priority=supplemental ort https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ort-cuda-12-nightly/pypi/simple/ && \
-  poetry add --source ort --group cuda ort-nightly-gpu && \
-  poetry remove --group cuda onnxruntime-gpu && \
+  poetry source add --no-interaction --no-ansi --priority=supplemental ort https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ort-cuda-12-nightly/pypi/simple/ && \
+  poetry add --lock --no-interaction --no-ansi --source ort --group cuda ort-nightly-gpu && \
+  poetry remove --lock --no-interaction --no-ansi --group cuda onnxruntime-gpu && \
   echo "**** cleanup ****" && \
   for cleanfiles in *.pyc *.pyo; do \
     find /usr/local/lib/python3.* /usr/lib/python3.* /lsiopy/lib/python3.* -name "${cleanfiles}" -delete; \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -13,10 +13,10 @@ LABEL maintainer="hydazz, martabal"
 ENV \
   IMMICH_MACHINE_LEARNING_URL="http://127.0.0.1:3003" \
   IMMICH_MEDIA_LOCATION="/photos" \
+  IMMICH_WEB_ROOT="/app/immich/server/www" \
   MACHINE_LEARNING_CACHE_FOLDER="/config/machine-learning/models" \
-  TRANSFORMERS_CACHE="/config/machine-learning/models" \
   SERVER_PORT="8080" \
-  IMMICH_WEB_ROOT="/app/immich/server/www"
+  TRANSFORMERS_CACHE="/config/machine-learning/models"
 
 RUN \
   echo "**** install build packages ****" && \

--- a/root/etc/s6-overlay/s6-rc.d/init-config-gpu-acceleration/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-config-gpu-acceleration/run
@@ -42,11 +42,9 @@ if [ "${MACHINE_LEARNING_GPU_ACCELERATION,,}" = "cuda" ]; then
         python3 -m venv "$venv_path"
     fi
 
-    # install/update pip packages to /config venv
-    # and install onnxruntime nightly until it supports cuda 12 https://github.com/Microsoft/onnxruntime/releases/
     echo "**** install python dependencies ****"
     source "$source_path"
-    cd /app/immich/machine-learning/cuda || exit
+    cd /app/immich/machine-learning || exit
     poetry install --sync --no-interaction --no-ansi --no-root --with cuda --without dev
 
 


### PR DESCRIPTION
Prevent to install dev packages used by machine learning. Reduce docker image size from `2.12GB` to `2GB` (uncompressed)