### PR TITLE
fix: build CLI (main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,19 @@ RUN \
     build/* \
     static \
     /app/immich/server/www  && \
+  echo "**** build CLI ****" && \
+  mkdir -p \
+    /app/immich/cli && \
+  cd /tmp/immich/cli && \
+  npm ci && \
+  npm run build && \
+  npm prune --omit=dev --omit=optional && \
+  cp -a \
+    package.json \
+    package-lock.json \
+    node_modules \
+    dist \
+    /app/immich/cli && \
   echo "**** build machine-learning ****" && \
   mkdir -p \
     /app/immich/machine-learning/ann && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -81,6 +81,19 @@ RUN \
     build/* \
     static \
     /app/immich/server/www  && \
+  echo "**** build CLI ****" && \
+  mkdir -p \
+    /app/immich/cli && \
+  cd /tmp/immich/cli && \
+  npm ci && \
+  npm run build && \
+  npm prune --omit=dev --omit=optional && \
+  cp -a \
+    package.json \
+    package-lock.json \
+    node_modules \
+    dist \
+    /app/immich/cli && \
   echo "**** build machine-learning ****" && \
   mkdir -p \
     /app/immich/machine-learning/ann && \

--- a/root/usr/local/bin/immich
+++ b/root/usr/local/bin/immich
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-node /app/immich/server/node_modules/.bin/immich "$@"
+node /app/immich/cli/dist/index.js "$@"


### PR DESCRIPTION
In next Immich version, the CLI used to upload assets will be removed from the server dependencies. This PR builds the CLI to be sure to always have the latest CLI version (the one from the npm registry has a risk to be outdated).

This PR can be merged now.