### PR TITLE
feat: apply permission to the correct media location (main)

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-config-immich/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-config-immich/run
@@ -4,13 +4,11 @@
 # make folders
 mkdir -p \
     /config/machine-learning/models \
-    /photos \
-    /run/immich
+    "$IMMICH_MEDIA_LOCATION"
 
 # permissions
-find /photos -maxdepth 0 \( ! -user abc -o ! -group abc \) -exec lsiown -R abc:abc {} \;
+find "$IMMICH_MEDIA_LOCATION" -maxdepth 0 \( ! -user abc -o ! -group abc \) -exec lsiown -R abc:abc {} \;
 find /app/immich -path "*/node_modules" -prune -o -exec chown abc:abc {} +
 lsiown -R abc:abc \
     /config \
-    /run/immich \
     /usr/src/resources


### PR DESCRIPTION
If someone uses a media location other than `/photos` (can happen if you migrate from docker-compose method to the AIO).