### PR TITLE
fix: broken link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Immich is a high performance self-hosted photo and video backup solution.
 
 ## Supported Architectures
 
-We use Docker manifest for cross-platform compatibility. More details can be found on [Docker's website](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list).
+We use Docker manifest for cross-platform compatibility. More details can be found on [Docker's website](https://github.com/distribution/distribution/blob/main/docs/content/spec/manifest-v2-2.md#manifest-list).
 
 To obtain the appropriate image for your architecture, simply pull `ghcr.io/imagegenius/immich:latest`. Alternatively, you can also obtain specific architecture images by using tags.
 


### PR DESCRIPTION
While looking through a repo i found that the link showed a 404 website. So i thought it shouldn't be that hard fixing it.