### PR TITLE
fix: breaking change (main)

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-microservices/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-microservices/run
@@ -2,7 +2,8 @@
 # shellcheck shell=bash
 
 lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2"
-export LD_PRELOAD="$lib_path"
+export LD_PRELOAD="${lib_path}"
+export IMMICH_WORKERS_INCLUDE="microservices"
 
 : "${CPU_CORES:="$(/app/immich/server/scripts/get-cpus.sh)"}"
 echo "Detected CPU Cores: ${CPU_CORES}"
@@ -12,4 +13,4 @@ fi
 
 exec \
     cd /app/immich/server s6-setuidgid abc \
-        node dist/main microservices || exit
+        node dist/main || exit

--- a/root/etc/s6-overlay/s6-rc.d/svc-server/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-server/run
@@ -6,8 +6,9 @@
 
 lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2"
 export LD_PRELOAD="${lib_path}"
+export IMMICH_WORKERS_INCLUDE="api"
 
 exec \
-    s6-notifyoncheck -d -n 300 -w 5000 -c "nc -z localhost 8080" \
+    s6-notifyoncheck -d -n 300 -w 5000 -c "nc -z localhost ${IMMICH_PORT}" \
         cd /app/immich/server s6-setuidgid abc \
-            node dist/main immich
+            node dist/main


### PR DESCRIPTION
If you want to start a single worker, you have to specify which worker you want to start with an env. Until now you could start a single worker with a process arg, but that option will be removed in next version (`v1.118.0`)

Can be merged now.