### PR TITLE
remove IMMICH_REVERSE_GEOCODING_ROOT path

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-config-immich/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-config-immich/run
@@ -11,8 +11,7 @@ find /app/immich -path "*/node_modules" -prune -o -exec chown abc:abc {} +
 chown -R abc:abc \
     /config \
     "${IMMICH_MEDIA_LOCATION}" \
-    "${IMMICH_MEDIA_LOCATION}"/* \
-    /usr/src/resources
+    "${IMMICH_MEDIA_LOCATION}"/*
 
 if [[ "${APPLY_PERMISSIONS}" == "true" ]]; then
     lsiown -R abc:abc "${IMMICH_MEDIA_LOCATION}"


### PR DESCRIPTION
This version https://github.com/immich-app/immich/commit/5f25e2ce824b9a7a82561a78005d36ccd2f412fa has removed the /usr/src/resources path.