### PR TITLE
Update initialization script to create media directories

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-config-immich/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-config-immich/run
@@ -4,12 +4,7 @@
 # make folders
 mkdir -p \
     /config/machine-learning/models \
-    "${IMMICH_MEDIA_LOCATION}/library" \
-    "${IMMICH_MEDIA_LOCATION}/backups" \
-    "${IMMICH_MEDIA_LOCATION}/profile" \
-    "${IMMICH_MEDIA_LOCATION}/upload" \
-    "${IMMICH_MEDIA_LOCATION}/thumbs" \
-    "${IMMICH_MEDIA_LOCATION}/encoded-video"
+    "${IMMICH_MEDIA_LOCATION}"/{library,backups,profile,upload,thumbs,encoded-video}
 
 # permissions
 find /app/immich -path "*/node_modules" -prune -o -exec chown abc:abc {} +

--- a/root/etc/s6-overlay/s6-rc.d/init-config-immich/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-config-immich/run
@@ -4,12 +4,19 @@
 # make folders
 mkdir -p \
     /config/machine-learning/models \
-    "${IMMICH_MEDIA_LOCATION}/library"
+    "${IMMICH_MEDIA_LOCATION}/library" \
+    "${IMMICH_MEDIA_LOCATION}/backups" \
+    "${IMMICH_MEDIA_LOCATION}/profile" \
+    "${IMMICH_MEDIA_LOCATION}/upload" \
+    "${IMMICH_MEDIA_LOCATION}/thumbs" \
+    "${IMMICH_MEDIA_LOCATION}/encoded-video"
 
 # permissions
 find /app/immich -path "*/node_modules" -prune -o -exec chown abc:abc {} +
 chown -R abc:abc \
-    /config \
+    /config
+
+chown abc:abc \
     "${IMMICH_MEDIA_LOCATION}" \
     "${IMMICH_MEDIA_LOCATION}"/*
 


### PR DESCRIPTION
- Added creation of new directories: `backups`, `profile`, `upload`, `thumbs`, and `encoded-video` within `${IMMICH_MEDIA_LOCATION}`.
- Ensured proper permissions are set for the new directories to maintain consistency. 

- The command

```shell

chown -R abc:abc \
    "${IMMICH_MEDIA_LOCATION}" \
    "${IMMICH_MEDIA_LOCATION}"/*
```

> processes ${IMMICH_MEDIA_LOCATION}/library twice. If there are many files inside, it can significantly slow down the startup process.