### PR TITLE
fix: correct message for `IMMICH_PORT` and `IMMICH_HOST` (noml)

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-check-variables/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-check-variables/run
@@ -24,11 +24,9 @@ RED='\033[0;31m'
 NC='\033[0m'
 
 if [ -n "$IMMICH_PORT" ]; then
-    echo -e "${RED}Don't use \"IMMICH_PORT\":${NC} if you want to change the server port use the environment variable \"SERVER_PORT\", if you want to change the machine-learning port, use the environment variable \"MACHINE_LEARNING_PORT\""
-    sleep infinity
+    echo -e "${RED}Don't use \"IMMICH_PORT\":${NC} if you want to change the server port use the environment variable \"SERVER_PORT\""
 fi
 
 if [ -n "$IMMICH_HOST" ]; then
-    echo -e "${RED}Don't use \"IMMICH_HOST\":${NC} if you want to change the server host use the environment variable \"SERVER_HOST\", if you want to change the machine-learning host, use the environment variable \"MACHINE_LEARNING_HOST\"/"
-    sleep infinity
+    echo -e "${RED}Don't use \"IMMICH_HOST\":${NC} if you want to change the server host use the environment variable \"SERVER_HOST\""
 fi


### PR DESCRIPTION
There's no machine-learning in the noml image, no need to suggest the `MACHINE_LEARNING_* ` environment variables. And there's no port conflict, so no need for `sleep infinity`