### PR TITLE
fix: use same node version as upstream (main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM ghcr.io/imagegenius/baseimage-immich:latest
 ARG BUILD_DATE
 ARG VERSION
 ARG IMMICH_VERSION
+ARG NODEJS_VERSION
 LABEL build_version="ImageGenius Version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="hydazz, martabal"
 
@@ -17,28 +18,11 @@ ENV \
   IMMICH_MEDIA_LOCATION="/photos" \
   MACHINE_LEARNING_CACHE_FOLDER="/config/machine-learning/models" \
   NVIDIA_DRIVER_CAPABILITIES="compute,video,utility" \
-  SHARP_FORCE_GLOBAL_LIBVIPS=true \
+  SHARP_FORCE_GLOBAL_LIBVIPS="true" \
   TRANSFORMERS_CACHE="/config/machine-learning/models" \
   UV_PYTHON="/usr/bin/python3.11"
 
 RUN \
-  echo "**** install build packages ****" && \
-  echo "deb [signed-by=/usr/share/keyrings/deadsnakes.gpg] https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu noble main" >>/etc/apt/sources.list.d/deadsnakes.list && \
-  curl -s "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xF23C5A6CF475977595C89F51BA6932366A755776" | gpg --dearmor | tee /usr/share/keyrings/deadsnakes.gpg >/dev/null && \
-  apt-get update && \
-  apt-get install --no-install-recommends -y \
-    build-essential \
-    libexif-dev \
-    libexpat1-dev \
-    libglib2.0-dev \
-    libjpeg-dev \
-    librsvg2-dev \
-    libspng-dev \
-    pkg-config \
-    python3.11-dev && \
-  echo "**** install runtime packages ****" && \
-  apt-get install --no-install-recommends -y \
-    python3.11 && \
   echo "**** download immich ****" && \
   mkdir -p \
     /tmp/immich && \
@@ -52,6 +36,33 @@ RUN \
   tar xf \
     /tmp/immich.tar.gz -C \
     /tmp/immich --strip-components=1 && \
+  if [ -z "${NODEJS_VERSION}" ]; then \
+    NODEJS_VERSION="$(cat /tmp/immich/server/.nvmrc)" && \
+    echo "**** detected node version ${NODEJS_VERSION} ****"; \
+  fi && \
+  NODEJS_MAJOR_VERSION=$(echo "$NODEJS_VERSION" | cut -d '.' -f 1) && \
+  NODEJS_VERSION="${NODEJS_VERSION}-1nodesource1" && \
+  echo "**** setup repos ****" && \
+  echo "deb [signed-by=/usr/share/keyrings/nodesource-repo.gpg] https://deb.nodesource.com/node_${NODEJS_MAJOR_VERSION}.x nodistro main" >>/etc/apt/sources.list.d/node.list && \
+  curl -s "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key" | gpg --dearmor | tee /usr/share/keyrings/nodesource-repo.gpg >/dev/null && \
+  echo "deb [signed-by=/usr/share/keyrings/deadsnakes.gpg] https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu noble main" >>/etc/apt/sources.list.d/deadsnakes.list && \
+  curl -s "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xF23C5A6CF475977595C89F51BA6932366A755776" | gpg --dearmor | tee /usr/share/keyrings/deadsnakes.gpg >/dev/null && \
+  echo "**** install build packages ****" && \
+  apt-get update && \
+  apt-get install --no-install-recommends -y \
+    build-essential \
+    libexif-dev \
+    libexpat1-dev \
+    libglib2.0-dev \
+    libjpeg-dev \
+    librsvg2-dev \
+    libspng-dev \
+    pkg-config \
+    python3.11-dev && \
+  echo "**** install runtime packages ****" && \
+  apt-get install --no-install-recommends -y \
+    nodejs=$NODEJS_VERSION \
+    python3.11 && \
   echo "**** build server ****" && \
   mkdir -p \
     /tmp/node_modules && \
@@ -148,11 +159,13 @@ RUN \
   apt-get autoremove -y --purge && \
   apt-get clean && \
   rm -rf \
-    /tmp/* \
-    /var/tmp/* \
-    /var/lib/apt/lists/* \
+    /etc/apt/sources.list.d/node.list \
     /root/.cache \
-    /root/.npm
+    /root/.npm \
+    /tmp/* \
+    /usr/share/keyrings/nodesource-repo.gpg \
+    /var/lib/apt/lists/* \
+    /var/tmp/*
 
 # copy local files
 COPY root/ /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -6,6 +6,7 @@ FROM ghcr.io/imagegenius/baseimage-immich:arm64v8-latest
 ARG BUILD_DATE
 ARG VERSION
 ARG IMMICH_VERSION
+ARG NODEJS_VERSION
 LABEL build_version="ImageGenius Version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="hydazz, martabal"
 
@@ -16,28 +17,11 @@ ENV \
   IMMICH_MACHINE_LEARNING_URL="http://127.0.0.1:3003" \
   IMMICH_MEDIA_LOCATION="/photos" \
   MACHINE_LEARNING_CACHE_FOLDER="/config/machine-learning/models" \
-  SHARP_FORCE_GLOBAL_LIBVIPS=true \
+  SHARP_FORCE_GLOBAL_LIBVIPS="true" \
   TRANSFORMERS_CACHE="/config/machine-learning/models" \
   UV_PYTHON="/usr/bin/python3.11"
 
 RUN \
-  echo "**** install build packages ****" && \
-  echo "deb [signed-by=/usr/share/keyrings/deadsnakes.gpg] https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu noble main" >>/etc/apt/sources.list.d/deadsnakes.list && \
-  curl -s "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xF23C5A6CF475977595C89F51BA6932366A755776" | gpg --dearmor | tee /usr/share/keyrings/deadsnakes.gpg >/dev/null && \
-  apt-get update && \
-  apt-get install --no-install-recommends -y \
-    build-essential \
-    libexif-dev \
-    libexpat1-dev \
-    libglib2.0-dev \
-    libjpeg-dev \
-    librsvg2-dev \
-    libspng-dev \
-    pkg-config \
-    python3.11-dev && \
-  echo "**** install runtime packages ****" && \
-  apt-get install --no-install-recommends -y \
-    python3.11 && \
   echo "**** download immich ****" && \
   mkdir -p \
     /tmp/immich && \
@@ -51,6 +35,33 @@ RUN \
   tar xf \
     /tmp/immich.tar.gz -C \
     /tmp/immich --strip-components=1 && \
+  if [ -z "${NODEJS_VERSION}" ]; then \
+    NODEJS_VERSION="$(cat /tmp/immich/server/.nvmrc)" && \
+    echo "**** detected node version ${NODEJS_VERSION} ****"; \
+  fi && \
+  NODEJS_MAJOR_VERSION=$(echo "$NODEJS_VERSION" | cut -d '.' -f 1) && \
+  NODEJS_VERSION="${NODEJS_VERSION}-1nodesource1" && \
+  echo "**** setup repos ****" && \
+  echo "deb [signed-by=/usr/share/keyrings/nodesource-repo.gpg] https://deb.nodesource.com/node_${NODEJS_MAJOR_VERSION}.x nodistro main" >>/etc/apt/sources.list.d/node.list && \
+  curl -s "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key" | gpg --dearmor | tee /usr/share/keyrings/nodesource-repo.gpg >/dev/null && \
+  echo "deb [signed-by=/usr/share/keyrings/deadsnakes.gpg] https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu noble main" >>/etc/apt/sources.list.d/deadsnakes.list && \
+  curl -s "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xF23C5A6CF475977595C89F51BA6932366A755776" | gpg --dearmor | tee /usr/share/keyrings/deadsnakes.gpg >/dev/null && \
+  echo "**** install build packages ****" && \
+  apt-get update && \
+  apt-get install --no-install-recommends -y \
+    build-essential \
+    libexif-dev \
+    libexpat1-dev \
+    libglib2.0-dev \
+    libjpeg-dev \
+    librsvg2-dev \
+    libspng-dev \
+    pkg-config \
+    python3.11-dev && \
+  echo "**** install runtime packages ****" && \
+  apt-get install --no-install-recommends -y \
+    nodejs=$NODEJS_VERSION \
+    python3.11 && \
   echo "**** build server ****" && \
   mkdir -p \
     /tmp/node_modules && \
@@ -147,11 +158,13 @@ RUN \
   apt-get autoremove -y --purge && \
   apt-get clean && \
   rm -rf \
-    /tmp/* \
-    /var/tmp/* \
-    /var/lib/apt/lists/* \
+    /etc/apt/sources.list.d/node.list \
     /root/.cache \
-    /root/.npm
+    /root/.npm \
+    /tmp/* \
+    /usr/share/keyrings/nodesource-repo.gpg \
+    /var/lib/apt/lists/* \
+    /var/tmp/*
 
 # copy local files
 COPY root/ /


### PR DESCRIPTION
Use automatically the same nodejs version as the one used upstream.

Merge https://github.com/imagegenius/docker-baseimage-immich/pull/17 first