### PR TITLE
fix: Update the Dockerfile to add the installation of the mise plugin…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,10 @@ ENV \
   NVIDIA_DRIVER_CAPABILITIES="compute,video,utility" \
   SHARP_FORCE_GLOBAL_LIBVIPS="true" \
   TRANSFORMERS_CACHE="/config/machine-learning/models" \
-  UV_PYTHON="/usr/bin/python3.11"
+  UV_PYTHON="/usr/bin/python3.11"\
+  MISE_TRUSTED_CONFIG_PATHS="/app/immich/plugins/mise.toml"\
+  MISE_DATA_DIR="/buildcache/mise"\
+  NODE_OPTIONS="--max-old-space-size=8192"
 
 RUN \
   echo "**** download immich ****" && \
@@ -47,6 +50,8 @@ RUN \
   curl -s "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key" | gpg --dearmor | tee /usr/share/keyrings/nodesource-repo.gpg >/dev/null && \
   echo "deb [signed-by=/usr/share/keyrings/deadsnakes.gpg] https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu noble main" >>/etc/apt/sources.list.d/deadsnakes.list && \
   curl -s "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xF23C5A6CF475977595C89F51BA6932366A755776" | gpg --dearmor | tee /usr/share/keyrings/deadsnakes.gpg >/dev/null && \
+  echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.pub] https://mise.jdx.dev/deb stable main" >>/etc/apt/sources.list.d/mise.list && \
+  curl -fSs "https://mise.jdx.dev/gpg-key.pub" | tee /etc/apt/keyrings/mise-archive-keyring.pub 1> /dev/null && \
   echo "**** install build packages ****" && \
   apt-get update && \
   apt-get install --no-install-recommends -y \
@@ -59,7 +64,8 @@ RUN \
     librsvg2-dev \
     libspng-dev \
     pkg-config \
-    python3.11-dev && \
+    python3.11-dev \
+    mise && \
   echo "**** install runtime packages ****" && \
   apt-get install --no-install-recommends -y \
     nodejs=$NODEJS_VERSION \
@@ -67,6 +73,28 @@ RUN \
   echo "**** setup pnpm ****" && \
   npm install --global corepack@latest && \
   corepack enable pnpm && \
+  echo "**** setup plugins (mise) ****" && \
+  mkdir -p \
+    /app/immich/plugins && \
+  cp /tmp/immich/plugins/mise.toml /app/immich/plugins && \
+  mise install --cd /app/immich/plugins && \
+  echo "**** build plugins (mise) ****" && \
+  ls -a /tmp/immich/ && \
+  cp -a /tmp/immich/plugins/* /app/immich/plugins && \
+  cp /tmp/immich/.pnpmfile.cjs /app/immich/plugins && \
+  cp /tmp/immich/pnpm-lock.yaml /app/immich/plugins && \
+  cp /tmp/immich/pnpm-workspace.yaml /app/immich/plugins && \
+  ls -a /app/immich/plugins && \
+  cat /app/immich/plugins/package.json && \
+  sed -i 's/pnpm install --frozen-lockfile/pnpm install --no-frozen-lockfile/' /app/immich/plugins/mise.toml && \
+  cat /app/immich/plugins/mise.toml && \
+  mise run build --cd /app/immich/plugins && \
+  mkdir -p \
+    /app/immich/data/corePlugin && \
+  cp -a \
+    /app/immich/plugins/* \
+    /app/immich/data/corePlugin && \  
+  ls -a /app/immich/data/corePlugin && \
   echo "**** build server ****" && \
   mkdir -p \
     /tmp/node_modules && \
@@ -160,7 +188,8 @@ RUN \
     libspng-dev \
     libwebp-dev \
     pkg-config \
-    python3.11-dev && \
+    python3.11-dev \
+    mise && \
   apt-get autoremove -y --purge && \
   apt-get clean && \
   rm -rf \


### PR DESCRIPTION
… and the related environment variable settings, and fix the startup error.

see log :https://ci-tests.imagegenius.io/immich/openvino-v2.3.1-ig135/index.html
Due to an issue during startup where the system cannot find 

/app/immich/data/corePlugin/manifest.json,
I checked the Dockerfile in more detail:

```yaml
FROM builder AS plugins

COPY --from=ghcr.io/jdx/mise:2025.11.3@sha256:ac26f5978c0e2783f3e68e58ce75eddb83e41b89bf8747c503bac2aa9baf22c5 /usr/local/bin/mise /usr/local/bin/mise

WORKDIR /usr/src/app
COPY ./plugins/mise.toml ./plugins/
ENV MISE_TRUSTED_CONFIG_PATHS=/usr/src/app/plugins/mise.toml
ENV MISE_DATA_DIR=/buildcache/mise
RUN --mount=type=cache,id=mise-tools,target=/buildcache/mise \
  mise install --cd plugins

COPY ./plugins ./plugins/
# Build plugins
RUN --mount=type=cache,id=pnpm-plugins,target=/buildcache/pnpm-store \
  --mount=type=bind,source=package.json,target=package.json \
  --mount=type=bind,source=.pnpmfile.cjs,target=.pnpmfile.cjs \
  --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
  --mount=type=bind,source=pnpm-workspace.yaml,target=pnpm-workspace.yaml \
  --mount=type=cache,id=mise-tools,target=/buildcache/mise \
  cd plugins && mise run build

FROM ghcr.io/immich-app/base-server-prod:202511041104@sha256:57c0379977fd5521d83cdf661aecd1497c83a9a661ebafe0a5243a09fc1064cb

WORKDIR /usr/src/app
ENV NODE_ENV=production \
  NVIDIA_DRIVER_CAPABILITIES=all \
  NVIDIA_VISIBLE_DEVICES=all

COPY --from=server /output/server-pruned ./server
COPY --from=web /usr/src/app/web/build /build/www
COPY --from=cli /output/cli-pruned ./cli
COPY --from=plugins /usr/src/app/plugins/dist /build/corePlugin/dist
COPY --from=plugins /usr/src/app/plugins/manifest.json /build/corePlugin/manifest.json
```

I tried to fix it so that the system could start properly.