### PR TITLE
fix: preload installed libmimalloc soname instead of hardcoded so.2

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-machine-learning/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-machine-learning/run
@@ -7,8 +7,8 @@
 # stop machine learning from starting
 [[ "${DISABLE_MACHINE_LEARNING}" == "true" || "${IMMICH_MACHINE_LEARNING_URL}" != "http://127.0.0.1:3003" ]] && tail -f /dev/null
 
-lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2"
-export LD_PRELOAD="${lib_path}"
+lib_path="$(ls /usr/lib/$(arch)-linux-gnu/libmimalloc.so.* 2>/dev/null | sort -V | tail -1)"
+[[ -n "${lib_path}" ]] && export LD_PRELOAD="${lib_path}"
 export IMMICH_HOST="${MACHINE_LEARNING_HOST:-"0.0.0.0"}"
 export IMMICH_PORT="${MACHINE_LEARNING_PORT:-"3003"}"
 export MPLCONFIGDIR="/tmp"

--- a/root/etc/s6-overlay/s6-rc.d/svc-machine-learning/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-machine-learning/run
@@ -7,8 +7,7 @@
 # stop machine learning from starting
 [[ "${DISABLE_MACHINE_LEARNING}" == "true" || "${IMMICH_MACHINE_LEARNING_URL}" != "http://127.0.0.1:3003" ]] && tail -f /dev/null
 
-lib_path="$(ls /usr/lib/$(arch)-linux-gnu/libmimalloc.so.* 2>/dev/null | sort -V | tail -1)"
-[[ -n "${lib_path}" ]] && export LD_PRELOAD="${lib_path}"
+export LD_PRELOAD="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.3"
 export IMMICH_HOST="${MACHINE_LEARNING_HOST:-"0.0.0.0"}"
 export IMMICH_PORT="${MACHINE_LEARNING_PORT:-"3003"}"
 export MPLCONFIGDIR="/tmp"

--- a/root/etc/s6-overlay/s6-rc.d/svc-microservices/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-microservices/run
@@ -1,9 +1,8 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-lib_path="$(ls /usr/lib/$(arch)-linux-gnu/libmimalloc.so.* 2>/dev/null | sort -V | tail -1)"
 export IMMICH_WORKERS_INCLUDE="microservices"
-[[ -n "${lib_path}" ]] && export LD_PRELOAD="${lib_path}"
+export LD_PRELOAD="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.3"
 
 exec \
     cd /app/immich/server s6-setuidgid abc \

--- a/root/etc/s6-overlay/s6-rc.d/svc-microservices/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-microservices/run
@@ -1,9 +1,9 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2"
+lib_path="$(ls /usr/lib/$(arch)-linux-gnu/libmimalloc.so.* 2>/dev/null | sort -V | tail -1)"
 export IMMICH_WORKERS_INCLUDE="microservices"
-export LD_PRELOAD="${lib_path}"
+[[ -n "${lib_path}" ]] && export LD_PRELOAD="${lib_path}"
 
 exec \
     cd /app/immich/server s6-setuidgid abc \

--- a/root/etc/s6-overlay/s6-rc.d/svc-server/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-server/run
@@ -4,11 +4,11 @@
 # map disable variables to immich variables
 [[ "${DISABLE_MACHINE_LEARNING}" == "true" ]] && export IMMICH_MACHINE_LEARNING_ENABLED=false
 
-lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2"
+lib_path="$(ls /usr/lib/$(arch)-linux-gnu/libmimalloc.so.* 2>/dev/null | sort -V | tail -1)"
 export IMMICH_WORKERS_INCLUDE="api"
 export IMMICH_HOST="${SERVER_HOST:-"0.0.0.0"}"
 export IMMICH_PORT="${SERVER_PORT:-"8080"}"
-export LD_PRELOAD="${lib_path}"
+[[ -n "${lib_path}" ]] && export LD_PRELOAD="${lib_path}"
 
 exec \
     s6-notifyoncheck -d -n 300 -w 5000 -c "nc -z ${IMMICH_HOST} ${IMMICH_PORT}" \

--- a/root/etc/s6-overlay/s6-rc.d/svc-server/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-server/run
@@ -4,11 +4,10 @@
 # map disable variables to immich variables
 [[ "${DISABLE_MACHINE_LEARNING}" == "true" ]] && export IMMICH_MACHINE_LEARNING_ENABLED=false
 
-lib_path="$(ls /usr/lib/$(arch)-linux-gnu/libmimalloc.so.* 2>/dev/null | sort -V | tail -1)"
 export IMMICH_WORKERS_INCLUDE="api"
 export IMMICH_HOST="${SERVER_HOST:-"0.0.0.0"}"
 export IMMICH_PORT="${SERVER_PORT:-"8080"}"
-[[ -n "${lib_path}" ]] && export LD_PRELOAD="${lib_path}"
+export LD_PRELOAD="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.3"
 
 exec \
     s6-notifyoncheck -d -n 300 -w 5000 -c "nc -z ${IMMICH_HOST} ${IMMICH_PORT}" \

--- a/tests/container_test.go
+++ b/tests/container_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -71,4 +72,12 @@ func Test(t *testing.T) {
 	)
 	testcontainers.CleanupContainer(t, immich)
 	require.NoError(t, err, "immich failed to come up; check DB+Redis reachability and logs above")
+
+	logs, err := immich.Logs(ctx)
+	require.NoError(t, err)
+	defer logs.Close()
+
+	logBytes, err := io.ReadAll(logs)
+	require.NoError(t, err)
+	require.NotContains(t, string(logBytes), "cannot be preloaded")
 }


### PR DESCRIPTION
## What

The three s6 service `run` scripts preload a hardcoded `libmimalloc.so.2`:

```bash
lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2"
export LD_PRELOAD="${lib_path}"
```

but this image installs **`libmimalloc3`** (`Dockerfile` L85), which only ships `libmimalloc.so.3` — there is no `.so.2` in the image. So `ld.so` fails the preload on every start:

```
ERROR: ld.so: object '/usr/lib/x86_64-linux-gnu/libmimalloc.so.2' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
```

and immich falls back to the default glibc allocator instead of mimalloc.

This is specific to this packaging repo: the `libmimalloc3` bump happened here, while these s6 scripts (which don't exist upstream) still reference `.so.2`.

## Fix

Resolve whatever mimalloc soname is actually installed and only set `LD_PRELOAD` when one is found, so it won't regress on the next bump:

```bash
lib_path="$(ls /usr/lib/$(arch)-linux-gnu/libmimalloc.so.* 2>/dev/null | sort -V | tail -1)"
[[ -n "${lib_path}" ]] && export LD_PRELOAD="${lib_path}"
```

Applied to `svc-server`, `svc-microservices`, and `svc-machine-learning`.

## Testing

On a running `:latest` (immich 2.7.5, amd64):
- **before** — preload `ERROR` on every start, no mimalloc mapped into the node/python processes
- **after** (verified by pointing `LD_PRELOAD` at the resolved path) — no preload error, mimalloc loads, and server / microservices / ML all come up healthy (API `/api/server/ping` and ML `/ping` both return `pong`)

## Refs

Fixes #714. The same preload error is also reported in #715 and by @Starbix on #714.

One honest caveat: that line is logged as `ignored`, so I can't be certain it's the *proximate* cause of the hard `api worker exited with code 1` / ML-fatal symptoms in #715 and #714 — but this removes a real misconfiguration and restores mimalloc regardless, and is an easy thing to rule in/out for those reports.

Thanks for maintaining this image! 🙏
