### PR TITLE
fix(ci): emit OCI media types so zstd-compressed images are pullable (podman)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,7 +120,7 @@ jobs:
             *.labels.org.opencontainers.image.version=${{ needs.plan.outputs.version }}
             *.labels.org.opencontainers.image.revision=${{ github.sha }}
             *.labels.org.opencontainers.image.vendor=${{ github.repository_owner }}
-            *.output=type=image,name=ghcr.io/${{ github.repository_owner }}/immich,push-by-digest=true,name-canonical=true,push=true,compression=zstd,force-compression=true
+            *.output=type=image,name=ghcr.io/${{ github.repository_owner }}/immich,push-by-digest=true,name-canonical=true,push=true,compression=zstd,force-compression=true,oci-mediatypes=true
             *.tags=
 
       - name: Export Digest


### PR DESCRIPTION
## What

`podman pull ghcr.io/imagegenius/immich:latest` fails on Debian with:

```
Error: ... unsupported docker v2s2 media type: "application/vnd.docker.image.rootfs.diff.tar.zstd"
```

(reported in #711).

## Why

In `.github/workflows/build.yaml` the image is pushed with:

```
*.output=type=image,...,push=true,compression=zstd,force-compression=true
```

zstd-compressed layers are only valid inside an **OCI** image manifest. Without `oci-mediatypes=true`, buildkit emits a **Docker v2s2** manifest that references zstd layers — an unsupported combination, which podman (and other strict OCI clients / some containerd setups) refuse to pull.

## Fix

Add `oci-mediatypes=true` to the image output. This keeps the intended zstd compression but makes the manifest spec-compliant, so the image is pullable everywhere. GHCR and modern Docker/containerd/podman all support OCI manifests, so this shouldn't regress existing `docker pull` users.

```diff
- *.output=...,compression=zstd,force-compression=true
+ *.output=...,compression=zstd,force-compression=true,oci-mediatypes=true
```

(If you'd rather maximize compatibility over compression, `compression=gzip` is the conservative alternative — your call.)

## Testing

Full disclosure: I can't exercise the release pipeline (it runs on your infra/secrets), so I haven't produced a built artifact to pull-test. This is the documented buildx remedy for this exact `v2s2 + tar.zstd` error, and it's a CI-only change your build will validate on merge.

Fixes #711. Thanks again! 🙏
